### PR TITLE
Fixed missing colon

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,7 +4,7 @@
     register: yum_output
   - debug: var=yum_output
 
-  - name Check if reboot is needed
+  - name: Check if reboot is needed
     shell:
       cmd: /usr/bin/needs-restarting -r
     register: needs_restarting


### PR DESCRIPTION
Fixed missing colon in task of `tasks/main.yml`.
Signed-off-by: Joerg Kastning <joerg.kastning@uni-bielefeld.de>